### PR TITLE
Fix crash on unknown user w/o enroll

### DIFF
--- a/lib/duo_security/api.rb
+++ b/lib/duo_security/api.rb
@@ -34,7 +34,7 @@ module DuoSecurity
     def preauth(user)
       response = post("/preauth", {"user" => user})["response"]
 
-      raise UnknownUser, response.fetch("status") if response.fetch("result") == "enroll"
+      raise UnknownUser, response.fetch("status") if response.fetch("result") == "enroll" || response.fetch("result") == "deny"
 
       return response
     end


### PR DESCRIPTION
Don't crash if you have enrollment disabled and you try to
authenticate an unknown user.
